### PR TITLE
Jf/toggle editable cell editable

### DIFF
--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vsjs/table",
-  "version": "3.8.3+vsjs.1",
+  "version": "3.8.3-vsjs.1",
   "description": "Scalable interactive table component",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
@@ -74,6 +74,8 @@
     "spreadsheet"
   ],
   "author": "Palantir Technologies",
-  "contributors": ["Valsys Inc."],
+  "contributors": [
+    "Valsys Inc."
+  ],
   "license": "Apache-2.0"
 }

--- a/packages/table/src/cell/editableCell.tsx
+++ b/packages/table/src/cell/editableCell.tsx
@@ -71,6 +71,11 @@ export interface IEditableCellProps extends ICellProps {
      * Props that should be passed to the EditableText when it is used to edit
      */
     editableTextProps?: IEditableTextProps;
+
+    /**
+     * Whether the cell's editable functionality is active.
+     */
+    editable?: boolean;
 }
 
 export interface IEditableCellState {
@@ -223,7 +228,10 @@ export class EditableCell extends React.Component<IEditableCellProps, IEditableC
     };
 
     private handleEdit = () => {
-        this.setState({ isEditing: true, dirtyValue: this.state.savedValue });
+        const { editable } = this.props;
+        if (editable) {
+            this.setState({ isEditing: true, dirtyValue: this.state.savedValue });
+        }
     };
 
     private handleCancel = (value: string) => {


### PR DESCRIPTION
includes an editable prop on `EditableCell` that allows toggling of the editable behaviour without re-rendering as a `Cell`.